### PR TITLE
Added a list of application server ips or subnet masks

### DIFF
--- a/tests/SaasLandlordModuleTest.php
+++ b/tests/SaasLandlordModuleTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rhubarb\Scaffolds\Saas\Landlord\Tests;
+
+use Rhubarb\Scaffolds\Saas\Landlord\SaasLandlordModule;
+use Rhubarb\Scaffolds\Saas\Landlord\Tests\Fixtures\SaasTestCase;
+
+class SaasLandlordModuleTest extends SaasTestCase
+{
+    public function testCanRegisterAppServerIP()
+    {
+        SaasLandlordModule::clearRegisteredTenantServers();
+        SaasLandlordModule::registerTenantServer('192.168.1.1');
+        $this->assertCount(1, SaasLandlordModule::getTenantServerIPAddresses());
+    }
+
+    public function testCanRegisterAppServerMask()
+    {
+        SaasLandlordModule::clearRegisteredTenantServers();
+        SaasLandlordModule::registerTenantServer('192.168.1.0/24');
+        $this->assertCount(1, SaasLandlordModule::getTenantServerMasks());
+    }
+
+    public function testCanClearRegisteredAppServers()
+    {
+        SaasLandlordModule::clearRegisteredTenantServers();
+        SaasLandlordModule::registerTenantServer('192.168.1.1');
+        SaasLandlordModule::registerTenantServer('192.168.1.0/24');
+        SaasLandlordModule::clearRegisteredTenantServers();
+        $this->assertCount(0, SaasLandlordModule::getTenantServerIPAddresses());
+        $this->assertCount(0, SaasLandlordModule::getTenantServerMasks());
+    }
+
+    public function testIsAppServerByIP()
+    {
+        SaasLandlordModule::clearRegisteredTenantServers();
+        SaasLandlordModule::registerTenantServer('192.168.1.1');
+        $this->assertTrue(SaasLandlordModule::isTenantServer('192.168.1.1'));
+        $this->assertFalse(SaasLandlordModule::isTenantServer('192.168.2.1'));
+    }
+
+    public function testIsAppServerByMask()
+    {
+        SaasLandlordModule::clearRegisteredTenantServers();
+        SaasLandlordModule::registerTenantServer('192.168.1.0/24');
+        $this->assertTrue(SaasLandlordModule::isTenantServer('192.168.1.1'));
+        $this->assertFalse(SaasLandlordModule::isTenantServer('192.168.2.1'));
+    }
+}


### PR DESCRIPTION
These lists can be used when creating new DB users and the list of ip addresses can be used for performing actions on a tenant server.

One thing I'd like feedback on - I haven't set a default for this for localhost as it was before, so this will be a breaking change for existing projects unless they add a server registration line. Should I add a default of 127.0.0.1? I thought this seemed like a bad idea for a default, just because SaaS project components should ideally be deployed on separate servers.
